### PR TITLE
Option to force https

### DIFF
--- a/lib/force-https.js
+++ b/lib/force-https.js
@@ -1,8 +1,9 @@
 'use strict';
 
 function forceHttpsMiddleware(req, res, next) {
+  let ua = req.headers['user-agent'];
   // Skip redirect if header indicates edge server received request over HTTPS or request is ELB health check
-  if (req.headers['x-forwarded-proto'] === 'https' || req.headers['user-agent'].indexOf('HealthChecker') >= 0) {
+  if (req.headers['x-forwarded-proto'] === 'https' || (ua && ua.indexOf('HealthChecker') >= 0)) {
     return next();
   } else {
     // Otherwise redirect!

--- a/lib/force-https.js
+++ b/lib/force-https.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function forceHttpsMiddleware(req, res, next) {
+  // Skip redirect if header indicates edge server received request over HTTPS or request is ELB health check
+  if (req.headers['x-forwarded-proto'] === 'https' || req.headers['user-agent'].indexOf('HealthChecker') >= 0) {
+    return next();
+  } else {
+    // Otherwise redirect!
+    return res.redirect(301, `https://${req.hostname}${req.url}`);
+  }
+};
+
+module.exports = forceHttpsMiddleware;

--- a/server.js
+++ b/server.js
@@ -4,12 +4,14 @@ const S3Downloader      = require('fastboot-s3-downloader');
 const S3Notifier        = require('fastboot-s3-notifier');
 const RedisCache        = require('fastboot-redis-cache');
 const FastBootAppServer = require('fastboot-app-server');
+const forceHttps        = require('./lib/force-https');
 
 const S3_BUCKET    = process.env.FASTBOOT_S3_BUCKET;
 const S3_KEY       = process.env.FASTBOOT_S3_KEY;
 const REDIS_HOST   = process.env.FASTBOOT_REDIS_HOST;
 const REDIS_PORT   = process.env.FASTBOOT_REDIS_PORT;
 const REDIS_EXPIRY = process.env.FASTBOOT_REDIS_EXPIRY;
+const FORCE_HTTPS  = process.env.FORCE_HTTPS;
 const USERNAME     = process.env.FASTBOOT_USERNAME;
 const PASSWORD     = process.env.FASTBOOT_PASSWORD;
 
@@ -37,7 +39,12 @@ if (REDIS_HOST || REDIS_PORT) {
 let server = new FastBootAppServer({
   downloader: downloader,
   notifier: notifier,
-  cache: cache
+  cache: cache,
+  beforeMiddleware(app) {
+    if (FORCE_HTTPS) {
+      app.use(forceHttps);
+    }
+  }
 });
 
 server.start();


### PR DESCRIPTION
If `FORCE_HTTPS` is set, will make a redirect if not using https at the Load Balancer. Parts of it shamelessly stolen from https://github.com/ember-fastboot/fastboot-app-server/issues/36.

@tomdale ping!