### PR TITLE
Fix npm install failing due to access permissions

### DIFF
--- a/.ebextensions/00_create_postdeploy_script.config
+++ b/.ebextensions/00_create_postdeploy_script.config
@@ -1,0 +1,8 @@
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/post/99_fix_node_permissions.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      chown -R nodejs:nodejs /tmp/.npm/_locks/


### PR DESCRIPTION
I have seen `npm install` failing after downloading the new app with permission errors:
```
npm WARN locking Error: EACCES: permission denied, open '/tmp/.npm/_locks/staging-f212e8d64a01707f.lock'
```

This should fix it, based on http://stackoverflow.com/a/41616528